### PR TITLE
🔧 : – add PR reaper workflow and setup docs

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -1,0 +1,93 @@
+name: Close my open PRs
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be closed (no changes)"
+        type: boolean
+        default: true
+      org:
+        description: "Limit to an org (optional, e.g. your-org)"
+        type: string
+        default: ""
+      title_filter:
+        description: "Substring to match in PR title (optional, e.g. Codex)"
+        type: string
+        default: ""
+      delete_branch:
+        description: "Delete the PR source branch after closing"
+        type: boolean
+        default: false
+      limit:
+        description: "Max PRs to process (1–1000)"
+        type: number
+        default: 1000
+      comment:
+        description: "Closing comment"
+        type: string
+        default: "Closing as superseded by a newer Codex run."
+
+permissions:
+  contents: read
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN }}
+    steps:
+      - name: Install gh + jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh jq
+
+      - name: Build search query
+        id: q
+        run: |
+          Q="is:pr is:open author:@me"
+          if [ -n "${{ github.event.inputs.org }}" ]; then
+            Q="$Q org:${{ github.event.inputs.org }}"
+          fi
+          if [ -n "${{ github.event.inputs.title_filter }}" ]; then
+            # GitHub's search lacks a direct substring operator for title only.
+            # Use in:title to constrain to the title field.
+            Q="$Q in:title ${{ github.event.inputs.title_filter }}"
+          fi
+          echo "q=$Q" >> $GITHUB_OUTPUT
+
+      - name: Search PRs
+        id: search
+        run: |
+          gh search issues "${{ steps.q.outputs.q }}" \
+            --limit ${{ github.event.inputs.limit }} \
+            --json number,repositoryUrl,title,url,author,headRefName \
+            | tee prs.json
+
+          COUNT=$(jq 'length' prs.json)
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "Found $COUNT PRs"
+
+      - name: Dry-run listing
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          jq -r '.[] | "\(.url) — \(.title)"' prs.json
+
+      - name: Close PRs
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          DELETE_FLAG=""
+          if [ "${{ github.event.inputs.delete_branch }}" = "true" ]; then
+            DELETE_FLAG="--delete-branch"
+          fi
+
+          jq -r '.[] | "\(.number) \(.repositoryUrl)"' prs.json \
+          | while read -r NUMBER REPO_URL; do
+              REPO="${REPO_URL#https://github.com/}"
+              CMD="gh pr close $NUMBER --repo $REPO --comment \"${{ github.event.inputs.comment }}\""
+              if [ -n "$DELETE_FLAG" ]; then
+                CMD="$CMD $DELETE_FLAG"
+              fi
+              echo "$CMD"
+              eval "$CMD"
+            done

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# pr-reaper
-One-button GitHub Action to close all open pull requests authored by you. Designed for sweeping away orphaned or superseded PRs (e.g., from automated Codex runs) in bulk, with a safe dry-run mode before reaping begins.
+# PR Reaper
+
+One-button workflow to close all open pull requests authored by you. Designed for sweeping away
+orphaned or superseded PRs (e.g., from automated Codex runs) in bulk, with a safe dry-run mode
+before reaping begins.
+
+## Auth
+Create a fine-grained Personal Access Token and store it as a repo secret named
+`PR_REAPER_TOKEN`.
+
+- **Owner**: your user
+- **Resource access**: select the orgs/repos you want it to manage
+- **Permissions**: Repository → Pull requests: Read/Write, Contents: Read
+- If you need to act on private repos across multiple orgs, include those explicitly in the
+  token's resource access.
+
+Add it under: Repo → Settings → Secrets and variables → Actions → New repository secret →
+`PR_REAPER_TOKEN`.
+
+## Use
+1. Go to **Actions → Close my open PRs → Run workflow**.
+2. Leave **dry_run=true** to preview.
+3. When happy, re-run with **dry_run=false**.
+4. Optional inputs:
+   - `org`: only PRs in a specific org
+   - `title_filter`: only PRs with substring in the title (uses `in:title`)
+   - `delete_branch`: also delete the PR source branch
+   - `comment`: closing message


### PR DESCRIPTION
what: add GitHub Action to close open PRs and usage guide
why: enable one-button cleanup of superseded PRs
how to test: run workflow with dry_run=true

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68af7ac9ac0c832f8c2f6f5ee2c1fb04