### PR TITLE
🐛 : write message when no PRs found

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -79,7 +79,11 @@ jobs:
       - name: List PRs and write report
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
-          jq -r '.[] | "- [\(.title)](\(.url))"' prs.json | tee pr-report.md
+          jq -r '.[] | "- [\(.title)](\(.url))"' prs.json > pr-report.md
+          if [ ! -s pr-report.md ]; then
+            echo "No open PRs found." > pr-report.md
+          fi
+          cat pr-report.md
 
       - name: Upload PR report
         if: ${{ github.event.inputs.dry_run == 'true' }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Add it under: Repo → Settings → Secrets and variables → Actions → New re
 
 ## Use
 1. Go to **Actions → Close my open PRs → Run workflow**.
-2. Leave **dry_run=true** to preview.
+2. Leave **dry_run=true** to preview. The run uploads a `dry-run-prs`
+   artifact listing matching PRs or a note when none are found.
 3. When happy, re-run with **dry_run=false**.
 4. Optional inputs:
    - `org`: only PRs in a specific org


### PR DESCRIPTION
what: add fallback text to dry run report
why: avoid empty pr-report.md when search returns zero matches
how to test: run workflow dry_run=true with no open PRs; verify artifact
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68af811099e8832f981a2034d9879d49