### PR TITLE
🐛 : fail without GH_TOKEN

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -55,9 +55,24 @@ jobs:
           echo "gh auth status:"
           gh auth status || true
           echo "gh api user (login):"
-          gh api user --jq .login || true
+          LOGIN=$(gh api user --jq .login 2>/dev/null || true)
+          echo "${LOGIN:-"(none)"}"
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::GH_TOKEN is not set; gh may use GITHUB_TOKEN or be unauthenticated. Cross-repo searches can fail or return 0."
+            echo "::error::GH_TOKEN is not set; add PR_REAPER_TOKEN with repo scope."
+            exit 1
+          fi
+          if [ -z "$LOGIN" ]; then
+            echo "::error::gh is unauthenticated; check PR_REAPER_TOKEN."
+            exit 1
+          fi
+          SCOPES=$(gh api -i user 2>/dev/null | tr -d '\r' | sed -n 's/^x-oauth-scopes: //p')
+          echo "token scopes: ${SCOPES:-"(none)"}"
+          if ! grep -qw repo <<< "$SCOPES"; then
+            echo "::error::PR_REAPER_TOKEN lacks repo scope; search will be empty."
+            exit 1
+          fi
+          if ! grep -qw read:org <<< "$SCOPES"; then
+            echo "::warning::PR_REAPER_TOKEN lacks read:org; org PRs may be skipped."
           fi
 
       - name: Build search query

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ before reaping begins.
 This workflow uses the GitHub CLI (`gh`). In Actions, `gh` will authenticate as:
 
 - `GH_TOKEN` if set (recommended) — provide a **Personal Access Token (classic)** with `repo` and
-  `read:org`, saved as `PR_REAPER_TOKEN`, exported as `GH_TOKEN` in the job.
+  `read:org`, saved as `PR_REAPER_TOKEN`, exported as `GH_TOKEN` in the job. The workflow verifies
+  that the token includes `repo` and warns if `read:org` is missing.
 - Otherwise, it may fall back to `GITHUB_TOKEN` or be unauthenticated. `GITHUB_TOKEN` is only scoped
   to the current repo, so cross-repo searches will return nothing.
+
+If no token is detected, `gh` cannot determine the current user, or `repo` scope is missing, the
+workflow fails early with an error to avoid silently returning zero results.
 
 Tip: The workflow prints `gh auth status` and `gh api user --jq .login` so you can verify which
 identity `gh` is using.


### PR DESCRIPTION
what: error if gh lacks token or repo scope
why: avoid silent zero results
how to test: run workflow without PR_REAPER_TOKEN or remove repo scope

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68af889187b4832fbe381ab87fce7d01