### PR TITLE
fix: remove archived filter to restore PR search

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -98,7 +98,7 @@ jobs:
           if [ -z "$AUTHOR" ]; then
             AUTHOR="${{ github.actor }}"
           fi
-          Q="is:pr is:open author:${AUTHOR} archived:false"
+          Q="is:pr is:open author:${AUTHOR}"
           if [ -n "${{ github.event.inputs.org }}" ]; then
             Q="$Q org:${{ github.event.inputs.org }}"
           fi


### PR DESCRIPTION
## Summary
- remove archived:false from search query to allow gh to find open PRs

## Testing
- `npm run lint` (fails: Could not read package.json)
- `npm run test:ci` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68af8ea0cd10832f8974f501bbb8d801