### PR TITLE
🔒 enforce repo scope requirement for PR search

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -83,9 +83,14 @@ jobs:
           grep -Eiq '(^|[[:space:],])repo([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_repo=1 || true
           grep -Eiq '(^|[[:space:],])read:org([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_readorg=1 || true
 
+          ORG_INPUT="${{ github.event.inputs.org }}"
           if [ "$has_repo" -ne 1 ]; then
-            echo "::warning::Could not verify 'repo' scope from headers; continuing."
-            echo "::warning::The next API call will fail if insufficient."
+            echo "::error::GH_TOKEN lacks 'repo' scope; add PR_REAPER_TOKEN with repo scope."
+            exit 1
+          fi
+          if [ -n "$ORG_INPUT" ] && [ "$has_readorg" -ne 1 ]; then
+            echo "::error::GH_TOKEN lacks 'read:org' scope required for org searches."
+            exit 1
           fi
           if [ "$has_readorg" -ne 1 ]; then
             echo "::warning::Could not verify 'read:org'; org PRs may be skipped."

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ before reaping begins.
 This workflow uses the GitHub CLI (`gh`). In Actions, `gh` will authenticate as:
 
 - `GH_TOKEN` if set (recommended) — provide a **Personal Access Token (classic)** with `repo` and
-  `read:org`, saved as `PR_REAPER_TOKEN`, exported as `GH_TOKEN` in the job. The workflow verifies
-  that the token includes `repo` and warns if `read:org` is missing.
+  `read:org`, saved as `PR_REAPER_TOKEN`, exported as `GH_TOKEN` in the job. The workflow now fails
+  if `repo` scope is missing and warns when `read:org` is absent.
 - Otherwise, it may fall back to `GITHUB_TOKEN` or be unauthenticated. `GITHUB_TOKEN` is only scoped
   to the current repo, so cross-repo searches will return nothing.
+
+If you provide the `org` input, the token must include `read:org` scope or the workflow will exit
+early with an error.
 
 If no token is detected, `gh` cannot determine the current user, or `repo` scope is missing, the
 workflow fails early with an error to avoid silently returning zero results.


### PR DESCRIPTION
## Summary
- fail workflow when GH_TOKEN lacks repo scope
- error when org filter used without read:org scope
- document required scopes for tokens

## Testing
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `npm run lint` *(fails: could not read package.json)*
- `npm run test:ci` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ea0cd10832f8974f501bbb8d801