### PR TITLE
🐛 : – handle missing repository URLs

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -126,9 +126,7 @@ jobs:
               echo ""
               jq -r '
                 .[] |
-                "- [\(.title)](\(.url))  (" +
-                (.repository.url | sub("^https://github.com/"; "")) +
-                "#\(.number))"
+                "- [\(.title)](\(.url))  (\(.repository.nameWithOwner)#\(.number))"
               ' prs.json
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -146,9 +144,8 @@ jobs:
             DELETE_FLAG="--delete-branch"
           fi
           COMMENT="${{ github.event.inputs.comment }}"
-          jq -r '.[] | "\(.number)\t\(.repository.url)"' prs.json \
-          | while IFS=$'\t' read -r NUM REPO_URL; do
-              REPO="${REPO_URL#https://github.com/}"
+          jq -r '.[] | "\(.number)\t\(.repository.nameWithOwner)"' prs.json \
+          | while IFS=$'\t' read -r NUM REPO; do
               CMD=(gh pr close "$NUM" --repo "$REPO" --comment "$COMMENT")
               if [ -n "$DELETE_FLAG" ]; then
                 CMD+=("$DELETE_FLAG")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "pr-reaper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pr-reaper",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pr-reaper",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "echo 'no lint configured'",
+    "test": "node --test",
+    "test:ci": "node --test"
+  }
+}

--- a/test/steps.test.js
+++ b/test/steps.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+test('summary step lists repo names correctly', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pr-reaper-'));
+  const file = join(tmp, 'prs.json');
+  const data = [{
+    number: 1,
+    repository: { nameWithOwner: 'octo/repo' },
+    title: 'Fix',
+    url: 'https://github.com/octo/repo/pull/1'
+  }];
+  writeFileSync(file, JSON.stringify(data));
+  const out = execSync(
+    `jq -r '.[] | "- [\\(.title)](\\(.url))  (\\(.repository.nameWithOwner)#\\(.number))"' ${file}`
+  )
+    .toString()
+    .trim();
+  assert.strictEqual(out, '- [Fix](https://github.com/octo/repo/pull/1)  (octo/repo#1)');
+});
+
+test('close step outputs owner/repo pairs', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pr-reaper-'));
+  const file = join(tmp, 'prs.json');
+  const data = [{
+    number: 2,
+    repository: { nameWithOwner: 'octo/repo' },
+    title: 'Fix',
+    url: 'https://github.com/octo/repo/pull/2'
+  }];
+  writeFileSync(file, JSON.stringify(data));
+  const out = execSync(
+    `jq -r '.[] | "\\(.number)\\t\\(.repository.nameWithOwner)"' ${file}`
+  )
+    .toString()
+    .trim();
+  assert.strictEqual(out, '2\tocto/repo');
+});


### PR DESCRIPTION
what: use nameWithOwner for PR summary and closing; add jq tests
why: gh search prs omits repository.url, causing summary failure
how to test: npm ci && npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68af91dcef84832f80582433dd9af0a2