### PR TITLE
✨ : – allow excluding PR URLs from reaping

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -31,6 +31,10 @@ on:
         description: "Closing comment"
         type: string
         default: "Closing as superseded by a newer Codex run."
+      exclude_urls:
+        description: "Newline-separated PR URLs to skip (optional)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -109,7 +113,24 @@ jobs:
           fi
           echo "Search command: ${CMD[*]}"
           "${CMD[@]}" | tee prs.json
+
+          EXCLUDE_INPUT="${{ github.event.inputs.exclude_urls }}"
+          if [ -n "$EXCLUDE_INPUT" ]; then
+            printf '%s\n' "$EXCLUDE_INPUT" | tr -d '\r' | \
+              jq -R -s 'split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))' > exclude.json
+            EXCLUDE_COUNT=$(jq 'length' exclude.json)
+            if [ "$EXCLUDE_COUNT" -gt 0 ]; then
+              echo "Excluding $EXCLUDE_COUNT PR URL(s):"
+              jq -r '.[]' exclude.json
+              jq --argfile exclude exclude.json '
+                map(select(.url as $u | ($exclude | index($u)) | not))
+              ' prs.json > filtered.json
+              mv filtered.json prs.json
+            fi
+          fi
+
           COUNT=$(jq 'length' prs.json)
+          rm -f exclude.json filtered.json
           echo "Found $COUNT PR(s)"
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ identity `gh` is using.
 3. When happy, re-run with **dry_run=false**.
 4. Optional inputs:
    - `org`: only PRs in a specific org
-  - `title_filter`: only PRs with substring in the title (`gh search prs --search str --match title`)
+   - `title_filter`: only PRs with substring in the title (`gh search prs --search str --match title`)
    - `delete_branch`: also delete the PR source branch (default: true)
    - `comment`: closing message
+   - `exclude_urls`: newline-separated PR URLs to skip (paste a shortlist of active PRs)
 
 ## Development
 


### PR DESCRIPTION
what: add a multiline workflow input for newline-separated PR URLs to skip
and document the option in the README.
why: let users omit actively worked PRs beyond the hardcoded dspace rules.
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e360c55570832fb938fa2088e1abbd