### PR TITLE
Fix exclude filtering in close-my-open-prs workflow

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -122,10 +122,15 @@ jobs:
             if [ "$EXCLUDE_COUNT" -gt 0 ]; then
               echo "Excluding $EXCLUDE_COUNT PR URL(s):"
               jq -r '.[]' exclude.json
-              jq --argfile exclude exclude.json '
-                map(select(.url as $u | ($exclude | index($u)) | not))
-              ' prs.json > filtered.json
-              mv filtered.json prs.json
+              node <<'EOF'
+const { readFileSync, writeFileSync } = require('node:fs');
+
+const prs = JSON.parse(readFileSync('prs.json', 'utf8'));
+const exclude = new Set(JSON.parse(readFileSync('exclude.json', 'utf8')));
+const filtered = prs.filter(pr => !exclude.has(pr.url));
+
+writeFileSync('prs.json', JSON.stringify(filtered));
+EOF
             fi
           fi
 


### PR DESCRIPTION
what: replace jq argfile filtering with node script
why: runner jq lacks --argfile support causing workflow failure
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e362b28eb8832fb0393262cfe5ea03