### PR TITLE
🛠️ : – Restore manual close workflow dispatch

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -46,6 +46,7 @@ jobs:
     # Prefer a user PAT if provided. If PR_REAPER_TOKEN is not set, gh will likely use GITHUB_TOKEN (repo-scoped) or be unauthenticated.
     env:
       GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN }}
+      FALLBACK_GH_TOKEN: ${{ github.token }}
     steps:
       - name: Show auth identity
         run: |
@@ -58,8 +59,13 @@ jobs:
           echo "${LOGIN:-"(none)"}"
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GH_TOKEN is not set; add PR_REAPER_TOKEN with repo scope."
-            exit 1
+            if [ -n "${FALLBACK_GH_TOKEN:-}" ]; then
+              echo "::warning::GH_TOKEN is not set; falling back to the workflow GITHUB_TOKEN (repo-scoped)."
+              export GH_TOKEN="$FALLBACK_GH_TOKEN"
+            else
+              echo "::error::GH_TOKEN is not set; add PR_REAPER_TOKEN with repo scope."
+              exit 1
+            fi
           fi
           if [ -z "${LOGIN:-}" ]; then
             echo "::error::gh is unauthenticated; check PR_REAPER_TOKEN."


### PR DESCRIPTION
what:
- allow the close-my-open-prs workflow to fall back to the workflow token

why:
- manual dispatch currently exits when PR_REAPER_TOKEN is unset

how to test:
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68e36474a5b8832f947ea1dd036637e2