### PR TITLE
🛠️ : – restore manual dispatch for close PR workflow

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     # Prefer a user PAT if provided. If PR_REAPER_TOKEN is not set, gh will likely use GITHUB_TOKEN (repo-scoped) or be unauthenticated.
     env:
-      GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN }}
+      GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN != '' && secrets.PR_REAPER_TOKEN || github.token }}
     steps:
       - name: Show auth identity
         run: |


### PR DESCRIPTION
what: fallback to github.token when PR_REAPER_TOKEN is unset
why: enable manual dispatch without a custom token
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e36474a5b8832f947ea1dd036637e2