### PR TITLE
Restore manual dispatch fallback for close workflow

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -43,9 +43,12 @@ permissions:
 jobs:
   reap:
     runs-on: ubuntu-latest
-    # Prefer a user PAT if provided. If PR_REAPER_TOKEN is not set, gh will likely use GITHUB_TOKEN (repo-scoped) or be unauthenticated.
+    # Prefer a user PAT if provided. Fall back to the workflow token so manual dispatch still works
+    # even if PR_REAPER_TOKEN is not configured (limited to the current repository).
     env:
-      GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN }}
+      PR_REAPER_TOKEN: ${{ secrets.PR_REAPER_TOKEN }}
+      GH_TOKEN: ${{ secrets.PR_REAPER_TOKEN || github.token }}
+      TOKEN_SOURCE: ${{ secrets.PR_REAPER_TOKEN != '' && 'secret' || 'github-token' }}
     steps:
       - name: Show auth identity
         run: |
@@ -58,7 +61,7 @@ jobs:
           echo "${LOGIN:-"(none)"}"
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GH_TOKEN is not set; add PR_REAPER_TOKEN with repo scope."
+            echo "::error::GH_TOKEN is not set."
             exit 1
           fi
           if [ -z "${LOGIN:-}" ]; then
@@ -66,33 +69,42 @@ jobs:
             exit 1
           fi
 
-          # Case-insensitive header parse; some runners capitalize this header.
-          RAW_HEADERS="$(gh api -i user 2>/dev/null | tr -d '\r' || true)"
-          SCOPES="$(awk 'BEGIN{IGNORECASE=1} /^x-oauth-scopes:/ {sub(/^x-oauth-scopes:[[:space:]]*/,""); print}' \
-            <<< "$RAW_HEADERS")"
-
-          # Fallback: parse scopes from `gh auth status` if header isn’t present.
-          if [ -z "${SCOPES:-}" ]; then
-            SCOPES="$(gh auth status 2>/dev/null | sed -n 's/.*Token scopes: \(.*\)$/\1/p' | tr -d ,)"
-          fi
-          SCOPES_TRIM="$(echo "${SCOPES:-}" | xargs || true)"
-          echo "token scopes (best-effort): ${SCOPES_TRIM:-"(unknown)"}"
-
-          has_repo=0; has_readorg=0
-          grep -Eiq '(^|[[:space:],])repo([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_repo=1 || true
-          grep -Eiq '(^|[[:space:],])read:org([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_readorg=1 || true
-
+          TOKEN_SOURCE="${TOKEN_SOURCE:-github-token}"
           ORG_INPUT="${{ github.event.inputs.org }}"
-          if [ "$has_repo" -ne 1 ]; then
-            echo "::error::GH_TOKEN lacks 'repo' scope; add PR_REAPER_TOKEN with repo scope."
-            exit 1
-          fi
-          if [ -n "$ORG_INPUT" ] && [ "$has_readorg" -ne 1 ]; then
-            echo "::error::GH_TOKEN lacks 'read:org' scope required for org searches."
-            exit 1
-          fi
-          if [ "$has_readorg" -ne 1 ]; then
-            echo "::warning::Could not verify 'read:org'; org PRs may be skipped."
+
+          if [ "$TOKEN_SOURCE" = "secret" ]; then
+            # Case-insensitive header parse; some runners capitalize this header.
+            RAW_HEADERS="$(gh api -i user 2>/dev/null | tr -d '\r' || true)"
+            SCOPES="$(awk 'BEGIN{IGNORECASE=1} /^x-oauth-scopes:/ {sub(/^x-oauth-scopes:[[:space:]]*/,""); print}' \
+              <<< "$RAW_HEADERS")"
+
+            # Fallback: parse scopes from `gh auth status` if header isn’t present.
+            if [ -z "${SCOPES:-}" ]; then
+              SCOPES="$(gh auth status 2>/dev/null | sed -n 's/.*Token scopes: \(.*\)$/\1/p' | tr -d ,)"
+            fi
+            SCOPES_TRIM="$(echo "${SCOPES:-}" | xargs || true)"
+            echo "token scopes (best-effort): ${SCOPES_TRIM:-"(unknown)"}"
+
+            has_repo=0; has_readorg=0
+            grep -Eiq '(^|[[:space:],])repo([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_repo=1 || true
+            grep -Eiq '(^|[[:space:],])read:org([[:space:],]|$)' <<< "${SCOPES_TRIM:-}" && has_readorg=1 || true
+
+            if [ "$has_repo" -ne 1 ]; then
+              echo "::error::GH_TOKEN lacks 'repo' scope; add PR_REAPER_TOKEN with repo scope."
+              exit 1
+            fi
+            if [ -n "$ORG_INPUT" ] && [ "$has_readorg" -ne 1 ]; then
+              echo "::error::GH_TOKEN lacks 'read:org' scope required for org searches."
+              exit 1
+            fi
+            if [ "$has_readorg" -ne 1 ]; then
+              echo "::warning::Could not verify 'read:org'; org PRs may be skipped."
+            fi
+          else
+            echo "::notice::PR_REAPER_TOKEN is not configured; using workflow token (repo-scoped)."
+            if [ -n "$ORG_INPUT" ]; then
+              echo "::warning::Workflow token lacks 'read:org'; org searches may be incomplete."
+            fi
           fi
       - name: Search PRs
         # Use gh search prs to match results from GitHub UI.


### PR DESCRIPTION
what:
- allow close-my-open-prs workflow to fall back to github.token

why:
- manual dispatch failed when pr_reaper_token was not configured

how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e36474a5b8832f947ea1dd036637e2