### PR TITLE
Enable manual CI dispatch trigger and add regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
 
 jobs:
   test:

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const workflows = [
+  { path: '.github/workflows/ci.yml', name: 'CI' },
+  { path: '.github/workflows/close-my-open-prs.yml', name: 'Close my open PRs' }
+];
+
+for (const { path, name } of workflows) {
+  test(`${name} workflow exposes workflow_dispatch trigger`, () => {
+    const contents = readFileSync(path, 'utf8');
+    const hasDispatch = contents
+      .split(/\r?\n/)
+      .some(line => {
+        const trimmed = line.trim();
+        return trimmed.startsWith('workflow_dispatch:') && !trimmed.startsWith('#');
+      });
+
+    assert.ok(hasDispatch, `${name} workflow must support manual dispatch`);
+  });
+}


### PR DESCRIPTION
✨ : –
what: add workflow_dispatch trigger to ci workflow and test both workflows
why: restore manual run button and guard against regressions
how to test: npm run lint; npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68e3661ab104832fa290f83ad567c941