### PR TITLE
Restore manual dispatch for close-my-open-prs workflow

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -25,8 +25,7 @@ on:
         default: true
       limit:
         description: "Max PRs to process (1–1000)"
-        type: number
-        default: 1000
+        default: '1000'
       comment:
         description: "Closing comment"
         type: string
@@ -123,13 +122,13 @@ jobs:
               echo "Excluding $EXCLUDE_COUNT PR URL(s):"
               jq -r '.[]' exclude.json
               node <<'EOF'
-const { readFileSync, writeFileSync } = require('node:fs');
+  const { readFileSync, writeFileSync } = require('node:fs');
 
-const prs = JSON.parse(readFileSync('prs.json', 'utf8'));
-const exclude = new Set(JSON.parse(readFileSync('exclude.json', 'utf8')));
-const filtered = prs.filter(pr => !exclude.has(pr.url));
+  const prs = JSON.parse(readFileSync('prs.json', 'utf8'));
+  const exclude = new Set(JSON.parse(readFileSync('exclude.json', 'utf8')));
+  const filtered = prs.filter(pr => !exclude.has(pr.url));
 
-writeFileSync('prs.json', JSON.stringify(filtered));
+  writeFileSync('prs.json', JSON.stringify(filtered));
 EOF
             fi
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,23 @@
   "packages": {
     "": {
       "name": "pr-reaper",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "lint": "echo 'no lint configured'",
     "test": "node --test",
     "test:ci": "node --test"
+  },
+  "devDependencies": {
+    "yaml": "^2.8.1"
   }
 }

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { parse } from 'yaml';
+
+const workflowPath = new URL('../.github/workflows/close-my-open-prs.yml', import.meta.url);
+const workflowSource = readFileSync(workflowPath, 'utf8');
+const permissionsMarker = workflowSource.indexOf('\npermissions:');
+const headerSource = permissionsMarker === -1
+  ? workflowSource
+  : workflowSource.slice(0, permissionsMarker);
+const workflow = parse(headerSource);
+
+test('close-my-open-prs workflow supports manual dispatch', () => {
+  assert.ok(
+    workflow?.on?.workflow_dispatch,
+    'Expected close-my-open-prs workflow to define workflow_dispatch.'
+  );
+});
+
+test('close-my-open-prs workflow uses supported input types', () => {
+  const inputs = workflow?.on?.workflow_dispatch?.inputs ?? {};
+  const allowedTypes = new Set(['boolean', 'choice', 'environment', 'string']);
+
+  for (const [name, config] of Object.entries(inputs)) {
+    if (Object.prototype.hasOwnProperty.call(config, 'type')) {
+      assert.ok(
+        allowedTypes.has(config.type),
+        `Unsupported workflow_dispatch input type "${config.type}" for "${name}".`
+      );
+    }
+  }
+});


### PR DESCRIPTION
what: set limit input default as string and add regression tests
why: workflow_dispatch run button vanished with unsupported number type
how to test: npm run lint && npm run test:ci
Refs: #N/A

------
https://chatgpt.com/codex/tasks/task_e_68e3661ab104832fa290f83ad567c941