### PR TITLE
🛠️ Restore exclude filtering in close workflow

### DIFF
--- a/.github/workflows/close-my-open-prs.yml
+++ b/.github/workflows/close-my-open-prs.yml
@@ -135,15 +135,10 @@ jobs:
             if [ "$EXCLUDE_COUNT" -gt 0 ]; then
               echo "Excluding $EXCLUDE_COUNT PR URL(s):"
               jq -r '.[]' exclude.json
-              node <<'NODE'
-                const { readFileSync, writeFileSync } = require('node:fs');
-
-                const prs = JSON.parse(readFileSync('prs.json', 'utf8'));
-                const exclude = new Set(JSON.parse(readFileSync('exclude.json', 'utf8')));
-                const filtered = prs.filter(pr => !exclude.has(pr.url));
-
-                writeFileSync('prs.json', JSON.stringify(filtered));
-              NODE
+              jq --slurpfile exclude exclude.json '
+                map(select(.url as $url | ($exclude[0] | index($url)) | not))
+              ' prs.json > filtered.json
+              mv filtered.json prs.json
             fi
           fi
 


### PR DESCRIPTION
what: replace the node heredoc with jq-based filtering
why: heredoc terminator indentation crashed manual dispatch runs
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e37494a078832f946212dc658ff4c1